### PR TITLE
Fix coredump

### DIFF
--- a/secbpf.c
+++ b/secbpf.c
@@ -149,6 +149,9 @@ static const struct sock_filter preauth_insns[] = {
 #ifdef __NR_get_robust_list
 	SC_ALLOW(get_robust_list),
 #endif
+#ifdef __NR_getsockopt
+	SC_ALLOW(getsockopt),
+#endif
 	/* Default deny */
 	BPF_STMT(BPF_RET+BPF_K, SECCOMP_FILTER_FAIL),
 };


### PR DESCRIPTION
- Pass in the right regex_t pointer
- Set the proper size for socklen_t for accept
- Allow the proess to call getsockopt. We can probably remove this
  by passing in the address family with the sockets