### PR TITLE
Adjust SECCOMP BPF policy

### DIFF
--- a/secbpf.c
+++ b/secbpf.c
@@ -152,6 +152,16 @@ static const struct sock_filter preauth_insns[] = {
 #ifdef __NR_getsockname
 	SC_ALLOW(getsockname),
 #endif
+#ifdef __NR_fcntl
+	/*
+	 * NB: fcntl() and fstat is allowed in capsicum (FreeBSDS) however we probably
+	 * want to do some additional scoping based on arguments.
+	 */
+	SC_ALLOW(fcntl),
+	SC_ALLOW(fstat),
+	SC_ALLOW(lseek),
+	SC_ALLOW(ioctl),
+#endif
 	/* Default deny */
 	BPF_STMT(BPF_RET+BPF_K, SECCOMP_FILTER_FAIL),
 };


### PR DESCRIPTION
Allow the following syscalls:

- fcntl
- fstat
- lseek
- ioctl

All these syscalls are allowed in the FreeBSD capability mode sandbox,
however we are also in a position to do additional filtering based on
syscall arguments.  In most cases, these syscalls take in bitmasks
and integer flags, therefore we should be able to apply additional
filtering.